### PR TITLE
Use pyopenssl as SSL module instead of built-in

### DIFF
--- a/httpserver.py
+++ b/httpserver.py
@@ -116,7 +116,7 @@ def run(port, index, certpath=''):
         cert = paths[confs.BASE_DOMAIN]
         cherrypy.tools.force_tls = cherrypy.Tool("before_handler", force_tls)
         cherrypy.config.update({
-            'server.ssl_module': 'builtin',
+            'server.ssl_module': 'pyopenssl',
             'server.ssl_certificate': os.path.join(cert, "cert.pem"),
             'server.ssl_private_key': os.path.join(cert, "privkey.pem"),
             'server.ssl_certificate_chain': os.path.join(cert, "fullchain.pem"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 dnslib==0.9.16
 cherrypy==18.1.2
+pyOpenSSL==21.0.0


### PR DESCRIPTION
We've been using this project in our infrastructure and frequently get the following and other SSL errors(for eg: #12).
```
[18/Jun/2024:00:51:35] ENGINE Error in HTTPServer.serve
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/cheroot/server.py", line 1807, in serve
    self._connections.run(self.expiration_interval)
  File "/usr/local/lib/python3.10/dist-packages/cheroot/connections.py", line 198, in run
    self._run(expiration_interval)
  File "/usr/local/lib/python3.10/dist-packages/cheroot/connections.py", line 241, in _run
    new_conn = self._from_server_socket(self.server.socket)
  File "/usr/local/lib/python3.10/dist-packages/cheroot/connections.py", line 295, in _from_server_socket
    s, ssl_env = self.server.ssl_adapter.wrap(s)
  File "/usr/local/lib/python3.10/dist-packages/cheroot/ssl/builtin.py", line 270, in wrap
    s = self.context.wrap_socket(
  File "/usr/lib/python3.10/ssl.py", line 513, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.10/ssl.py", line 1100, in _create
    self.do_handshake()
  File "/usr/lib/python3.10/ssl.py", line 1371, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: BAD_KEY_SHARE] bad key share (_ssl.c:1007)
```
I've changed the server config to use the `pyopenssl` module instead of the default for SSL stuff. This fixes the above error.

Ref: https://stackoverflow.com/a/65842531/23609414